### PR TITLE
Pin Tornado to version 4.x.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ deps =
     pytest
     pytest-cov
     pytest-xdist
+    Tornado >= 4.4, < 5
 commands =
     py.test \
         --basetemp={envtmpdir} \


### PR DESCRIPTION
Travis still uses Python 2.7.6 which current Tornado versions refuse to work with.